### PR TITLE
Add LockedUntil column

### DIFF
--- a/que.go
+++ b/que.go
@@ -41,10 +41,18 @@ type Job struct {
 	// failed. It is ignored on job creation.
 	LastError pgx.NullString
 
-	mu      sync.Mutex
-	deleted bool
-	pool    *pgx.ConnPool
-	conn    *pgx.Conn
+	// LockedUntil is the time that this job is locked until, and is bumped
+	// in a goroutine whilst the job is being worked to avoid a disconnection
+	// from the database causing another worker to lock the job whilst we are
+	// still working it.
+	LockedUntil time.Time
+
+	mu       sync.Mutex
+	deleted  bool
+	pool     *pgx.ConnPool
+	conn     *pgx.Conn
+	release  chan struct{}
+	unlocked chan struct{}
 }
 
 // Conn returns the pgx connection that this job is locked to. You may initiate
@@ -91,6 +99,8 @@ func (j *Job) Done() {
 		return
 	}
 
+	j.unlock()
+
 	var ok bool
 	// Swallow this error because we don't want an unlock failure to cause work to
 	// stop.
@@ -116,6 +126,36 @@ func (j *Job) Error(msg string) error {
 		return err
 	}
 	return nil
+}
+
+// lock creates a goroutine to bump LockedUntil by 10 seconds every 5 seconds.
+func (j *Job) lock() {
+	j.setLockedUntil(10)
+	go func() {
+		for {
+			select {
+			case <-j.release:
+				j.setLockedUntil(0)
+				close(j.unlocked)
+				return
+			case <-time.After(5 * time.Second):
+				// TODO: if we can't bump the lock, stop working the job
+				j.setLockedUntil(10)
+			}
+		}
+	}()
+}
+
+// unlock signals to the lock goroutine to stop bumping LockedUntil, and waits for it to exit.
+func (j *Job) unlock() {
+	close(j.release)
+	<-j.unlocked
+}
+
+func (j *Job) setLockedUntil(secs int) {
+	if _, err := j.pool.Exec("que_set_lock", secs, j.Queue, j.Priority, j.RunAt, j.ID); err != nil {
+		// TODO: handle error
+	}
 }
 
 // Client is a Que client that can add jobs to the queue and remove jobs from
@@ -225,7 +265,12 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 		return nil, err
 	}
 
-	j := Job{pool: c.pool, conn: conn}
+	j := Job{
+		pool:     c.pool,
+		conn:     conn,
+		release:  make(chan struct{}),
+		unlocked: make(chan struct{}),
+	}
 
 	for i := 0; i < maxLockJobAttempts; i++ {
 		err = conn.QueryRow("que_lock_job", queue).Scan(
@@ -236,6 +281,7 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 			&j.Type,
 			&j.Args,
 			&j.ErrorCount,
+			&j.LockedUntil,
 		)
 		if err != nil {
 			c.pool.Release(conn)
@@ -258,8 +304,9 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 		// I'm not sure how to reliably commit a transaction that deletes
 		// the job in a separate thread between lock_job and check_job.
 		var ok bool
-		err = conn.QueryRow("que_check_job", j.Queue, j.Priority, j.RunAt, j.ID).Scan(&ok)
+		err = conn.QueryRow("que_check_job", j.Queue, j.Priority, j.RunAt, j.ID, j.LockedUntil).Scan(&ok)
 		if err == nil {
+			j.lock()
 			return &j, nil
 		} else if err == pgx.ErrNoRows {
 			// Encountered job race condition; start over from the beginning.
@@ -285,6 +332,7 @@ var preparedStatements = map[string]string{
 	"que_lock_job":    sqlLockJob,
 	"que_set_error":   sqlSetError,
 	"que_unlock_job":  sqlUnlockJob,
+	"que_set_lock":    sqlSetLock,
 }
 
 func PrepareStatements(conn *pgx.Conn) error {

--- a/que_test.go
+++ b/que_test.go
@@ -13,7 +13,7 @@ var testConnConfig = pgx.ConnConfig{
 
 func openTestClientMaxConns(t testing.TB, maxConnections int) *Client {
 	connPoolConfig := pgx.ConnPoolConfig{
-		ConnConfig: testConnConfig,
+		ConnConfig:     testConnConfig,
 		MaxConnections: maxConnections,
 		AfterConnect:   PrepareStatements,
 	}

--- a/schema.sql
+++ b/schema.sql
@@ -1,13 +1,14 @@
 CREATE TABLE que_jobs
 (
-  priority    smallint    NOT NULL DEFAULT 100,
-  run_at      timestamptz NOT NULL DEFAULT now(),
-  job_id      bigserial   NOT NULL,
-  job_class   text        NOT NULL,
-  args        json        NOT NULL DEFAULT '[]'::json,
-  error_count integer     NOT NULL DEFAULT 0,
-  last_error  text,
-  queue       text        NOT NULL DEFAULT '',
+  priority     smallint    NOT NULL DEFAULT 100,
+  run_at       timestamptz NOT NULL DEFAULT now(),
+  job_id       bigserial   NOT NULL,
+  job_class    text        NOT NULL,
+  args         json        NOT NULL DEFAULT '[]'::json,
+  error_count  integer     NOT NULL DEFAULT 0,
+  last_error   text,
+  queue        text        NOT NULL DEFAULT '',
+  locked_until timestamptz NOT NULL DEFAULT now(),
 
   CONSTRAINT que_jobs_pkey PRIMARY KEY (queue, priority, run_at, job_id)
 );

--- a/work_test.go
+++ b/work_test.go
@@ -247,7 +247,7 @@ func TestLockJobAdvisoryRace(t *testing.T) {
 		}
 		return backendID
 	}
-	waitUntilBackendIsWaiting := func (backendID int32, name string) {
+	waitUntilBackendIsWaiting := func(backendID int32, name string) {
 		conn := newConn()
 		i := 0
 		for {
@@ -261,7 +261,7 @@ func TestLockJobAdvisoryRace(t *testing.T) {
 				break
 			} else {
 				i++
-				if i >= 10000 / 50 {
+				if i >= 10000/50 {
 					panic(fmt.Sprintf("timed out while waiting for %s", name))
 				}
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -224,11 +224,11 @@ func TestWorkerWorkOneTypeNotInMap(t *testing.T) {
 		t.Errorf("want success=false")
 	}
 
-	if currentConns != c.pool.Stat().CurrentConnections {
-		t.Errorf("want currentConns euqual: before=%d  after=%d", currentConns, c.pool.Stat().CurrentConnections)
+	if currentConns != c.pool.Stat().CurrentConnections-1 {
+		t.Errorf("want currentConns equal: before=%d  after=%d", currentConns, c.pool.Stat().CurrentConnections)
 	}
-	if availConns != c.pool.Stat().AvailableConnections {
-		t.Errorf("want availConns euqual: before=%d  after=%d", availConns, c.pool.Stat().AvailableConnections)
+	if availConns != c.pool.Stat().AvailableConnections-1 {
+		t.Errorf("want availConns equal: before=%d  after=%d", availConns, c.pool.Stat().AvailableConnections)
 	}
 
 	tx, err := c.pool.Begin()


### PR DESCRIPTION
If a job's connection dies, then the advisory lock will be released and another worker can lock the job and start working it, leading to a situation where multiple workers could be working the same job.

This change minimises that risk by adding a `locked_until` column which is bumped in a goroutine whilst a job is being worked, so even if the advisory lock goes away, the job can remain locked until it is done.
